### PR TITLE
Aligned common dependency version for all Alfresco 3.4 connectors

### DIFF
--- a/bonita-connector-alfresco34-uploadfile-impl/pom.xml
+++ b/bonita-connector-alfresco34-uploadfile-impl/pom.xml
@@ -21,7 +21,7 @@
 		<dependency>
 			<groupId>org.bonitasoft.connectors</groupId>
 			<artifactId>bonita-connector-alfresco34-common</artifactId>
-			<version>1.1.1</version>
+			<version>1.1.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.bonitasoft.connectors</groupId>


### PR DESCRIPTION
Alfresco 3.4 upload file connector had an older common dependency version than the others connectors.