### PR TITLE
tr(jenkins): replace deprecated ALT_DEPLOYMENT_REPOSITORY_TAG

### DIFF
--- a/infrastructure/release.groovy
+++ b/infrastructure/release.groovy
@@ -10,7 +10,7 @@ timestamps {
                             passwordVariable: 'GIT_PASSWORD',
                             usernameVariable: 'GIT_USERNAME')]) {
                                 sh """
-                                    ./mvnw -B release:prepare release:perform -Darguments="-Djvm=${env.JAVA_HOME_11}/bin/java -DaltDeploymentRepository=${env.ALT_DEPLOYMENT_REPOSITORY_TAG}"
+                                    ./mvnw -B release:prepare release:perform -Darguments="-Djvm=${env.JAVA_HOME_11}/bin/java -DaltDeploymentRepository=${env.ALT_DEPLOYMENT_REPOSITORY_STAGING}"
                                 """
                        }
                 }


### PR DESCRIPTION
Jenkins global env var `ALT_DEPLOYMENT_REPOSITORY_TAG` is deprecated. `ALT_DEPLOYMENT_REPOSITORY_STAGING` is used instead.